### PR TITLE
fix: set up rspec all system include model + controller > 50%

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,14 +33,15 @@ class Ability
 
   def define_zone_and_device_permissions user
     can :manage, Zone, user_id: user.id
-    can :manage, Camera, zone: {user_id: user.id}
-    can :manage, Sensor, zone: {user_id: user.id}
+    can [:create, :read, :update], Camera, zone: {user_id: user.id}
+    can :capture_and_upload_snapshot, Camera, zone: {user_id: user.id}
+    can [:create, :read, :update], Sensor, zone: {user_id: user.id}
   end
 
   def define_alert_and_log_permissions user
     can :read, Alert, zone: {user_id: user.id}
     can :update_status, Alert, zone: {user_id: user.id}
     can :read, SensorLog, sensor: {zone: {user_id: user.id}}
-    can [:chart, :stats], SensorLog
+    can :chart, SensorLog
   end
 end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -19,15 +19,17 @@ class Alert < ApplicationRecord
 
   scope :newest, ->{order(created_at: :desc)}
   scope :with_status, (lambda do |status|
-    where(status:) if status.present? && statuses.key?(status)
+    where(status: statuses[status] || -1) if status.present?
   end)
   scope :in_date_range, lambda {|start_date, end_date|
     return unless start_date.present? && end_date.present?
 
     begin
-      start_time = Time.zone.parse(start_date.to_s).beginning_of_day
-      end_time = Time.zone.parse(end_date.to_s).end_of_day
-      where(created_at: start_time..end_time)
+      start_time = Time.zone.parse(start_date.to_s)
+      end_time = Time.zone.parse(end_date.to_s)
+      return all unless start_time && end_time
+
+      where(created_at: start_time.beginning_of_day..end_time.end_of_day)
     rescue ArgumentError
       all
     end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -3,6 +3,13 @@ class Zone < ApplicationRecord
   has_many :sensors, dependent: :destroy
   has_many :cameras, dependent: :destroy
   has_many :alerts, dependent: :destroy
+  validates :name,
+            presence: true,
+            uniqueness: {
+              scope: :user_id,
+              message: I18n.t("zones.errors.name_uniqueness")
+            }
+  validates :user, presence: true
   scope :with_location, (lambda do
     where.not(city: nil)
          .or(where.not(latitude: nil, longitude: nil))

--- a/app/services/notifications/telegram_service.rb
+++ b/app/services/notifications/telegram_service.rb
@@ -33,7 +33,23 @@ module Notifications
     end
 
     def build_message
-      I18n.t("services.notifications.telegram.message_html", i18n_params)
+      zone_name = @alert.zone.name
+      owner_name = @alert.owner.name
+      owner_type = @alert.owner_type
+      timestamp = @alert.created_at
+                        .in_time_zone(TIMEZONE)
+                        .strftime(TIMESTAMP_FORMAT)
+
+      <<~MSG
+        *🔥 CẢNH BÁO CHÁY KHẨN CẤP 🔥*
+
+        *Khu vực:* #{zone_name}
+        *Thiết bị:* #{owner_name} (#{owner_type})
+        *Thời gian:* #{timestamp}
+
+        *Nội dung:*
+        #{@alert.message}
+      MSG
     end
 
     def i18n_params

--- a/config/locales/zone/zone.en.yml
+++ b/config/locales/zone/zone.en.yml
@@ -9,6 +9,7 @@ en:
       failure: "Zone creation failed"
     errors:
       not_found: "Zone not found."
+      name_uniqueness: "should be unique for each supervisor"
     update:
       success: "Zone updated successfully"
       failure: "Zone update failed"

--- a/config/locales/zone/zone.vi.yml
+++ b/config/locales/zone/zone.vi.yml
@@ -9,6 +9,7 @@ vi:
       failure: "Tạo vùng thất bại"
     errors:
       not_found: "Không tìm thấy khu vực."
+      name_uniqueness: "phải là duy nhất cho mỗi giám sát"
     update:
       success: "Cập nhật vùng thành công"
       failure: "Cập nhật vùng thất bại"

--- a/db/migrate/20250828075929_add_unique_index_to_zones_name_and_user_id.rb
+++ b/db/migrate/20250828075929_add_unique_index_to_zones_name_and_user_id.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToZonesNameAndUserId < ActiveRecord::Migration[7.0]
+  def change
+    add_index :zones, [:name, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_08_16_095443) do
+ActiveRecord::Schema[7.0].define(version: 2025_08_28_075929) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -150,6 +150,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_16_095443) do
     t.datetime "updated_at", null: false
     t.integer "sensors_count", default: 0
     t.integer "cameras_count", default: 0
+    t.index ["name", "user_id"], name: "index_zones_on_name_and_user_id", unique: true
     t.index ["user_id"], name: "index_zones_on_user_id"
   end
 

--- a/spec/factories/sensor_logs.rb
+++ b/spec/factories/sensor_logs.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+    factory :sensor_log do
+        sensor
+        temperature { rand(20.0..40.0).round(1) }
+        humidity { rand(30..70) }
+    end
+end

--- a/spec/factories/sensors.rb
+++ b/spec/factories/sensors.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+    factory :sensor do
+        sequence(:name) { |n| "Sensor #{n}" }
+        location { Faker::Address.street_address }
+        status { :active }
+        threshold { 50.0 }
+        sensitivity { 5 }
+        zone
+    end
+end

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -1,0 +1,116 @@
+require "rails_helper"
+
+RSpec.describe Alert, type: :model do
+    let(:camera) { create(:camera) }
+    let(:zone) { camera.zone }
+
+    describe "validations" do
+        subject { build(:alert, owner: camera, zone: zone) }
+
+        it { is_expected.to validate_presence_of(:message) }
+        it { is_expected.to validate_presence_of(:owner) }
+        it { is_expected.to validate_presence_of(:zone) }
+
+        it "is valid with valid attributes" do
+            expect(subject).to be_valid
+        end
+    end
+
+    describe "associations" do
+        it { is_expected.to belong_to(:owner) }
+        it { is_expected.to belong_to(:zone) }
+        it { is_expected.to belong_to(:user).optional }
+        it { is_expected.to have_one_attached(:snapshot) }
+    end
+
+    describe "enums" do
+        it do
+            is_expected.to define_enum_for(:status)
+                .with_values(pending: 0, resolved: 1, ignored: 2)
+        end
+        it do
+            is_expected.to define_enum_for(:origin)
+                .with_values(sensor_threshold: 0, sensor_error: 1, ml_detection: 2, manual_input: 3)
+        end
+    end
+
+    describe "scopes" do
+        let!(:pending_alert) { create(:alert, owner: camera, zone: zone, status: :pending, created_at: 2.days.ago) }
+        let!(:resolved_alert) { create(:alert, owner: camera, zone: zone, status: :resolved, created_at: 1.day.ago) }
+
+        describe ".newest" do
+            it "orders alerts by creation date descending" do
+                expect(Alert.newest).to eq([resolved_alert, pending_alert])
+            end
+        end
+
+        describe ".with_status" do
+            it "returns alerts with the specified status" do
+                expect(Alert.with_status("pending")).to contain_exactly(pending_alert)
+            end
+
+            it "returns all alerts if status is nil" do
+                expect(Alert.with_status(nil)).to contain_exactly(pending_alert, resolved_alert)
+            end
+
+            it "returns no alerts if status is invalid" do
+                expect(Alert.with_status("invalid_status")).to be_empty
+            end
+        end
+
+        describe ".in_date_range" do
+            it "returns alerts within the specified date range" do
+                start_date = 3.days.ago.to_date.to_s
+                end_date = Time.current.to_date.to_s
+                expect(Alert.in_date_range(start_date, end_date)).to contain_exactly(pending_alert, resolved_alert)
+            end
+
+            it "returns nothing if the range is outside the creation dates" do
+                start_date = 4.days.ago.to_date.to_s
+                end_date = 3.days.ago.to_date.to_s
+                expect(Alert.in_date_range(start_date, end_date)).to be_empty
+            end
+
+            it "returns all alerts if end_date is missing" do
+                expect(Alert.in_date_range(3.days.ago.to_s, nil)).to contain_exactly(pending_alert, resolved_alert)
+            end
+
+            it "returns all alerts if start_date is missing" do
+                expect(Alert.in_date_range(nil, Time.current.to_s)).to contain_exactly(pending_alert, resolved_alert)
+            end
+
+            it "returns all alerts for invalid date formats" do
+                expect(Alert.in_date_range("invalid-date", "2025-01-01")).to contain_exactly(pending_alert, resolved_alert)
+            end
+        end
+    end
+
+    describe "methods" do
+        describe "#notification_recipient" do
+            it "returns the user associated with the zone" do
+                alert = build(:alert, zone: zone)
+                expect(alert.notification_recipient).to eq(zone.user)
+            end
+        end
+
+        describe ".pending_count" do
+            it "returns the count of pending alerts" do
+                create(:alert, owner: camera, zone: zone, status: :pending)
+                create(:alert, owner: camera, zone: zone, status: :resolved)
+                expect(Alert.pending_count).to eq(1)
+            end
+        end
+    end
+
+    describe "constants" do
+        it "defines ALERT_PERMIT with correct attributes" do
+            expected_permit = %i[message origin status via_email owner_id owner_type zone_id]
+            expect(Alert::ALERT_PERMIT).to match_array(expected_permit)
+        end
+
+        it "defines ALERTS_PRELOAD with correct associations" do
+            expected_preload = %i[user zone owner]
+            expect(Alert::ALERTS_PRELOAD).to match_array(expected_preload)
+        end
+    end
+end

--- a/spec/models/sensor_log_spec.rb
+++ b/spec/models/sensor_log_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe SensorLog, type: :model do
+    describe "validations" do
+        it { is_expected.to validate_presence_of(:sensor_id) }
+        it { is_expected.to validate_numericality_of(:temperature).allow_nil }
+        it { is_expected.to validate_numericality_of(:humidity).allow_nil }
+    end
+
+    describe "associations" do
+        it { is_expected.to belong_to(:sensor) }
+    end
+
+    describe "scopes" do
+        let!(:sensor) { create(:sensor) }
+        let!(:log_now) { create(:sensor_log, sensor: sensor, created_at: Time.current, temperature: 30) }
+        let!(:log_1_hour_ago) { create(:sensor_log, sensor: sensor, created_at: 1.hour.ago, temperature: 28) }
+        let!(:log_25_hours_ago) { create(:sensor_log, sensor: sensor, created_at: 25.hours.ago, temperature: 25) }
+
+        describe ".newest" do
+            it "orders by created_at descending" do
+                expect(SensorLog.newest.first).to eq(log_now)
+            end
+        end
+
+        describe ".recent_hours(24)" do
+            it "returns logs within the last 24 hours" do
+                expect(SensorLog.recent_hours(24)).to contain_exactly(log_now, log_1_hour_ago)
+            end
+        end
+
+        describe ".with_temperature" do
+            it "returns logs that have a temperature" do
+                create(:sensor_log, sensor: sensor, temperature: nil)
+                expect(SensorLog.with_temperature).to contain_exactly(log_now, log_1_hour_ago, log_25_hours_ago)
+            end
+        end
+
+        describe ".by_sensor_ids" do
+            it "returns logs for the given sensor ids" do
+                other_sensor = create(:sensor)
+                log_for_other_sensor = create(:sensor_log, sensor: other_sensor)
+                expect(SensorLog.by_sensor_ids([other_sensor.id])).to contain_exactly(log_for_other_sensor)
+            end
+        end
+
+        describe ".created_after" do
+            it "returns logs created after a specific time" do
+                expect(SensorLog.created_after(2.hours.ago)).to contain_exactly(log_now, log_1_hour_ago)
+            end
+        end
+
+        describe ".in_time_range" do
+            it "returns logs within a specific time range" do
+                start_time = 1.5.hours.ago
+                end_time = 0.5.hours.ago
+                expect(SensorLog.in_time_range(start_time, end_time)).to contain_exactly(log_1_hour_ago)
+            end
+        end
+    end
+
+    describe "constants" do
+        it "defines CHART_DATA_COLUMNS correctly" do
+            expect(SensorLog::CHART_DATA_COLUMNS).to eq(%w[sensor_id created_at temperature humidity])
+        end
+    end
+end

--- a/spec/models/sensor_spec.rb
+++ b/spec/models/sensor_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe Sensor, type: :model do
+    describe "validations" do
+        it { is_expected.to validate_presence_of(:name) }
+        it { is_expected.to validate_presence_of(:location) }
+        it { is_expected.to validate_presence_of(:status) }
+    end
+
+    describe "associations" do
+        it { is_expected.to belong_to(:zone).counter_cache(true) }
+        it { is_expected.to have_many(:sensor_logs).dependent(:destroy) }
+        it { is_expected.to have_one(:latest_log).class_name('SensorLog') }
+
+        it "has many alerts as owner" do
+            sensor = create(:sensor)
+            alert1 = create(:alert, owner: sensor, zone: sensor.zone)
+            alert2 = create(:alert, owner: sensor, zone: sensor.zone)
+            expect(sensor.alerts).to include(alert1, alert2)
+        end
+
+        it "destroys associated alerts when destroyed" do
+            sensor = create(:sensor)
+            create(:alert, owner: sensor, zone: sensor.zone)
+            expect { sensor.destroy }.to change(Alert, :count).by(-1)
+        end
+    end
+
+    describe "enums" do
+        it do
+            is_expected.to define_enum_for(:status)
+                .with_values(active: 0, inactive: 1, error: 2)
+        end
+    end
+
+    describe "scopes" do
+        describe ".newest" do
+            it "orders sensors by creation date descending" do
+                oldest = create(:sensor, created_at: 1.day.ago)
+                newest = create(:sensor, created_at: Time.current)
+                expect(Sensor.newest).to eq([newest, oldest])
+            end
+        end
+    end
+
+    describe "Ransack configuration" do
+        it "returns a whitelist of searchable attributes" do
+            expected_attrs = %w[name location status threshold created_at]
+            expect(Sensor.ransackable_attributes).to match_array(expected_attrs)
+        end
+
+        it "returns a whitelist of searchable associations" do
+            expected_assocs = %w[zone]
+            expect(Sensor.ransackable_associations).to match_array(expected_assocs)
+        end
+    end
+
+    describe "constants" do
+        it "defines SENSOR_PERMITTED with correct attributes" do
+            expected = %i[name location status zone_id threshold sensitivity latitude longitude]
+            expect(Sensor::SENSOR_PERMITTED).to match_array(expected)
+        end
+
+        it "defines PRELOAD with correct associations" do
+            expected = %i[zone latest_log]
+            expect(Sensor::PRELOAD).to match_array(expected)
+        end
+    end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+    describe "validations" do
+        subject { build(:user, :supervisor) }
+
+        it { is_expected.to validate_presence_of(:name) }
+        it { is_expected.to validate_length_of(:name).is_at_most(50) }
+        it { is_expected.to validate_presence_of(:email) }
+        it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
+        it { is_expected.to allow_value("user@example.com").for(:email) }
+        it { is_expected.not_to allow_value("userexample.com").for(:email) }
+        it { is_expected.to validate_presence_of(:role) }
+        it { is_expected.to validate_presence_of(:password) }
+        it { is_expected.to validate_length_of(:password).is_at_least(6) }
+
+        context "custom validations" do
+            it "adds an error if an admin has an admin_id" do
+                admin_user = build(:user, :admin)
+                admin_user.admin_id = create(:user, :admin).id
+                admin_user.send(:admin_must_not_have_an_admin)
+                expect(admin_user.errors[:admin_id]).to include(I18n.t("activerecord.errors.models.user.attributes.admin_id.cannot_be_set_for_admin"))
+            end
+
+            it "is invalid if a supervisor does not have an admin on create" do
+                supervisor = build(:user, :supervisor, admin: nil)
+                expect(supervisor).not_to be_valid
+                expect(supervisor.errors[:admin]).to include(I18n.t("activerecord.errors.models.user.attributes.admin.must_exist_for_supervisor"))
+            end
+        end
+    end
+
+    describe "associations" do
+        it { is_expected.to have_many(:tokens).dependent(:destroy) }
+        it { is_expected.to have_many(:zones).dependent(:destroy) }
+        it { is_expected.to have_many(:invitations).dependent(:destroy) }
+        it { is_expected.to have_many(:supervisors).with_foreign_key('admin_id').dependent(:nullify).inverse_of(:admin) }
+
+        it "allows an admin to not have an admin" do
+            admin = build(:user, :admin, admin: nil)
+            expect(admin).to be_valid
+        end
+
+        it "requires a supervisor to have an admin" do
+            supervisor = build(:user, :supervisor, admin: nil)
+            expect(supervisor).not_to be_valid
+        end
+    end
+
+    describe "enums" do
+        it { is_expected.to define_enum_for(:role).with_values(supervisor: 0, admin: 1) }
+    end
+
+    describe "scopes" do
+        it ".newest orders users by creation date descending" do
+            User.destroy_all
+            admin = create(:user, :admin)
+            oldest = create(:user, :supervisor, admin: admin, created_at: 1.day.ago)
+            newest = create(:user, :supervisor, admin: admin, created_at: Time.current)
+            expect(User.where(role: :supervisor).newest).to eq([newest, oldest])
+        end
+    end
+
+    describe "password reset methods" do
+        let(:user) { create(:user, :supervisor) }
+
+        it "#generate_password_reset_token! sets token and timestamp" do
+            expect { user.generate_password_reset_token! }
+                .to change(user, :password_reset_token).from(nil)
+                .and change(user, :password_reset_sent_at).from(nil)
+        end
+
+        it "#password_reset_token_valid? returns true for recent token" do
+            user.generate_password_reset_token!
+            expect(user.password_reset_token_valid?).to be true
+        end
+
+        it "#password_reset_token_valid? returns false for expired token" do
+            user.generate_password_reset_token!
+            travel_to(3.hours.from_now) do
+                expect(user.password_reset_token_valid?).to be false
+            end
+        end
+
+        it "#clear_password_reset_token! nils out token fields" do
+            user.generate_password_reset_token!
+            user.clear_password_reset_token!
+            expect(user.password_reset_token).to be_nil
+            expect(user.password_reset_sent_at).to be_nil
+        end
+    end
+end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe Zone, type: :model do
+    describe "associations" do
+        it { is_expected.to belong_to(:user) }
+        it { is_expected.to have_many(:sensors).dependent(:destroy) }
+        it { is_expected.to have_many(:cameras).dependent(:destroy) }
+        it { is_expected.to have_many(:alerts).dependent(:destroy) }
+    end
+
+    describe "scopes" do
+        let!(:zone_with_city) { create(:zone, city: "Hanoi") }
+        let!(:zone_with_coords) { create(:zone, city: nil, latitude: 10.0, longitude: 106.0) }
+        let!(:zone_without_location) { create(:zone, city: nil, latitude: nil, longitude: nil) }
+
+        let!(:zone_with_active_sensor) { create(:zone) }
+        let!(:active_sensor) { create(:sensor, zone: zone_with_active_sensor, status: :active) }
+
+        let!(:zone_with_inactive_sensor) { create(:zone) }
+        let!(:inactive_sensor) { create(:sensor, zone: zone_with_inactive_sensor, status: :inactive) }
+
+        describe ".with_location" do
+            it "includes zones with a city" do
+                expect(Zone.with_location).to include(zone_with_city)
+            end
+
+            it "includes zones with latitude and longitude" do
+                expect(Zone.with_location).to include(zone_with_coords)
+            end
+
+            it "excludes zones without any location data" do
+                expect(Zone.with_location).not_to include(zone_without_location)
+            end
+        end
+
+        describe ".with_active_sensors" do
+            it "includes zones that have at least one active sensor" do
+                expect(Zone.with_active_sensors).to include(zone_with_active_sensor)
+            end
+
+            it "excludes zones that only have inactive sensors" do
+                expect(Zone.with_active_sensors).not_to include(zone_with_inactive_sensor)
+            end
+        end
+    end
+
+    describe "Ransack configuration" do
+        describe ".ransackable_attributes" do
+            it "returns a whitelist of searchable attributes" do
+                expected_attrs = %w[name description city created_at sensors_count cameras_count]
+                expect(Zone.ransackable_attributes).to match_array(expected_attrs)
+            end
+        end
+
+        describe ".ransackable_associations" do
+            it "returns a whitelist of searchable associations" do
+                expected_assocs = %w[user sensors cameras]
+                expect(Zone.ransackable_associations).to match_array(expected_assocs)
+            end
+        end
+    end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/api/v1/alerts_spec.rb
+++ b/spec/requests/api/v1/alerts_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::AlertsController, type: :controller do
+    let!(:admin_user) { create(:user, :admin) }
+    let!(:supervisor_user) { create(:user, :supervisor, admin: admin_user) }
+    let!(:other_supervisor) { create(:user, :supervisor, admin: admin_user) }
+
+    def allow_authentication(user)
+        allow(controller).to receive(:authenticate_request!).and_return(true)
+        controller.instance_variable_set(:@current_user, user)
+    end
+
+    describe "GET #index" do
+        let!(:supervisor_zone) { create(:zone, user: supervisor_user) }
+        let!(:camera_in_zone) { create(:camera, zone: supervisor_zone) }
+        let!(:alert_in_zone) { create(:alert, owner: camera_in_zone, zone: supervisor_zone, message: "Supervisor's Alert", status: :pending) }
+
+        let!(:other_zone) { create(:zone, user: other_supervisor) }
+        let!(:camera_in_other_zone) { create(:camera, zone: other_zone) }
+        let!(:alert_in_other_zone) { create(:alert, owner: camera_in_other_zone, zone: other_zone, message: "Other's Alert", status: :pending) }
+
+        context "when authenticated as an admin" do
+            it "returns a list of all alerts" do
+                allow_authentication(admin_user)
+                get :index, format: :json
+                expect(response).to have_http_status(:ok)
+                expect(JSON.parse(response.body)["data"].size).to eq(2)
+            end
+        end
+
+        context "when authenticated as a supervisor" do
+            it "returns only the alerts in their zones" do
+                allow_authentication(supervisor_user)
+                get :index, format: :json
+                expect(response).to have_http_status(:ok)
+                json_response = JSON.parse(response.body)
+                expect(json_response["data"].size).to eq(1)
+                expect(json_response["data"][0]["message"]).to eq("Supervisor's Alert")
+            end
+        end
+
+        context "with Ransack search parameters" do
+            before { allow_authentication(admin_user) }
+
+            it "filters by status" do
+                create(:alert, owner: camera_in_zone, zone: supervisor_zone, status: :resolved)
+                get :index, params: { q: { status_eq: 0 } }, format: :json
+                json_response = JSON.parse(response.body)
+                expect(json_response["data"].size).to eq(2)
+                json_response["data"].each { |alert| expect(alert["status"]).to eq("pending") }
+            end
+
+            it "handles invalid JSON in q param" do
+                get :index, params: { q: "{invalid_json" }, format: :json
+                expect(response).to have_http_status(:bad_request)
+            end
+        end
+    end
+
+    describe "GET #stats" do
+        before { allow_authentication(admin_user) }
+
+        it "returns the count of pending alerts" do
+            Alert.destroy_all
+            create_list(:alert, 3, status: :pending, owner: create(:camera), zone: create(:zone))
+            create_list(:alert, 2, status: :resolved, owner: create(:camera), zone: create(:zone))
+
+            get :stats, format: :json
+            expect(response).to have_http_status(:ok)
+            expect(JSON.parse(response.body)["pending"]).to eq(3)
+        end
+    end
+
+    describe "GET #show" do
+        let(:supervisor_zone) { create(:zone, user: supervisor_user) }
+        let(:alert_in_zone) { create(:alert, owner: create(:camera, zone: supervisor_zone), zone: supervisor_zone) }
+        let(:alert_in_other_zone) { create(:alert, owner: create(:camera), zone: create(:zone)) }
+
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user) }
+
+            it "can view their own alert" do
+                get :show, params: { id: alert_in_zone.id }, format: :json
+                expect(response).to have_http_status(:ok)
+            end
+
+            it "cannot view an alert from another's zone" do
+                get :show, params: { id: alert_in_other_zone.id }, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+    end
+
+    describe "POST #create" do
+        let(:zone) { create(:zone) }
+        let(:camera) { create(:camera, zone: zone) }
+        let(:valid_params) { { alert: { message: "Manual Alert", owner_id: camera.id, owner_type: "Camera", zone_id: zone.id } } }
+
+        context "when authenticated as an admin" do
+            before { allow_authentication(admin_user) }
+
+            it "can create a new alert" do
+                expect {
+                    post :create, params: valid_params, format: :json
+                }.to change(Alert, :count).by(1)
+                expect(response).to have_http_status(:created)
+            end
+
+            it "returns unprocessable entity with invalid parameters" do
+                post :create, params: { alert: { message: "" } }, format: :json
+                expect(response).to have_http_status(:unprocessable_entity)
+            end
+        end
+
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user) }
+
+            it "cannot create a new alert" do
+                expect {
+                    post :create, params: valid_params, format: :json
+                }.not_to change(Alert, :count)
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+    end
+
+    describe "PATCH #update_status" do
+        let(:alert_to_update) { create(:alert, owner: create(:camera), zone: create(:zone, user: supervisor_user)) }
+
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user) }
+
+            it "can update status of their own alert" do
+                patch :update_status, params: { id: alert_to_update.id, status: "resolved" }, format: :json
+                expect(response).to have_http_status(:ok)
+                expect(alert_to_update.reload.status).to eq("resolved")
+            end
+        end
+
+        context "when update fails" do
+            before do
+                allow_authentication(admin_user)
+                service_result = Alerts::StatusUpdaterService::Result.new(success?: false, errors: ["Update failed"])
+                allow_any_instance_of(Alerts::StatusUpdaterService).to receive(:call).and_return(service_result)
+            end
+
+            it "returns an unprocessable entity status" do
+                patch :update_status, params: { id: alert_to_update.id, status: "resolved" }, format: :json
+                expect(response).to have_http_status(:unprocessable_entity)
+                json_response = JSON.parse(response.body)
+                expect(json_response["error"]).to eq(["Update failed"])
+            end
+        end
+    end
+end

--- a/spec/requests/api/v1/cameras_spec.rb
+++ b/spec/requests/api/v1/cameras_spec.rb
@@ -3,24 +3,22 @@ require "rails_helper"
 RSpec.describe Api::V1::CamerasController, type: :controller do
     let!(:admin_user) { create(:user, :admin) }
     let!(:supervisor_user) { create(:user, :supervisor, admin: admin_user) }
-    let!(:zone) { create(:zone, user: supervisor_user) }
-    let!(:camera1) { create(:camera, zone: zone, name: "Lobby Camera") }
-    let!(:camera2) { create(:camera, zone: zone, name: "Parking Camera") }
+    let!(:other_supervisor) { create(:user, :supervisor, admin: admin_user) }
+
+    let!(:supervisor_zone) { create(:zone, user: supervisor_user) }
+    let!(:camera_in_zone) { create(:camera, zone: supervisor_zone, name: "Supervisor's Camera 1") }
+    let!(:camera2_in_zone) { create(:camera, zone: supervisor_zone, name: "Supervisor's Camera 2") }
+
+    let!(:other_zone) { create(:zone, user: other_supervisor) }
+    let!(:camera_in_other_zone) { create(:camera, zone: other_zone, name: "Other Supervisor's Camera") }
 
     def allow_authentication(user)
         allow(controller).to receive(:authenticate_request!).and_return(true)
-        allow(controller).to receive(:authorize_admin!).and_return(true)
         controller.instance_variable_set(:@current_user, user)
     end
 
     def allow_unauthorized_access
         allow(controller).to receive(:authenticate_request!).and_raise(Api::V1::BaseController::NotAuthenticatedError)
-    end
-
-    def allow_forbidden_access(user)
-        allow(controller).to receive(:authenticate_request!).and_return(true)
-        controller.instance_variable_set(:@current_user, user)
-        allow(controller).to receive(:authorize_admin!).and_raise(Api::V1::BaseController::NotAuthorizedError)
     end
 
     describe "GET #index" do
@@ -34,20 +32,26 @@ RSpec.describe Api::V1::CamerasController, type: :controller do
                 expect(response).to have_http_status(:ok)
             end
 
-            it "returns a success message" do
-                expect(JSON.parse(response.body)["message"]).to eq(I18n.t("api.v1.cameras.index.success"))
-            end
-
-            it "returns a list of all cameras" do
-                expect(JSON.parse(response.body)["data"].size).to eq(2)
+            it "returns a list of ALL cameras" do
+                expect(JSON.parse(response.body)["data"].size).to eq(3)
             end
         end
 
-        context "when authenticated as a non-admin" do
-            it "returns a forbidden status" do
-                allow_forbidden_access(supervisor_user)
+        context "when authenticated as a supervisor" do
+            before do
+                allow_authentication(supervisor_user)
                 get :index, format: :json
-                expect(response).to have_http_status(:forbidden)
+            end
+
+            it "returns a successful http status" do
+                expect(response).to have_http_status(:ok)
+            end
+
+            it "returns ONLY the cameras in their zones" do
+                json_response = JSON.parse(response.body)
+                expect(json_response["data"].size).to eq(2)
+                camera_names = json_response["data"].map { |c| c["name"] }
+                expect(camera_names).to contain_exactly("Supervisor's Camera 1", "Supervisor's Camera 2")
             end
         end
 
@@ -61,229 +65,138 @@ RSpec.describe Api::V1::CamerasController, type: :controller do
     end
 
     describe "GET #show" do
-        before { allow_authentication(admin_user) }
+        context "when authenticated as an admin" do
+            before { allow_authentication(admin_user) }
 
-        context "with a valid camera ID" do
-            before { get :show, params: { id: camera1.id }, format: :json }
-            let(:json_response) { JSON.parse(response.body) }
-
-            it "returns a successful http status" do
+            it "can view any camera" do
+                get :show, params: { id: camera_in_other_zone.id }, format: :json
                 expect(response).to have_http_status(:ok)
-            end
-
-            it "returns the correct id" do
-                expect(json_response["id"]).to eq(camera1.id)
-            end
-
-            it "returns the correct name" do
-                expect(json_response["name"]).to eq(camera1.name)
-            end
-
-            it "returns the correct url" do
-                expect(json_response["url"]).to eq(camera1.url)
-            end
-
-            it "returns the correct latitude" do
-                expect(json_response["latitude"]).to eq(camera1.latitude)
-            end
-
-            it "returns the correct longitude" do
-                expect(json_response["longitude"]).to eq(camera1.longitude)
-            end
-
-            it "returns the correct status" do
-                expect(json_response["status"]).to eq(camera1.status)
-            end
-
-            it "returns the correct is_detecting flag" do
-                expect(json_response["is_detecting"]).to eq(camera1.is_detecting)
-            end
-
-            it "returns the correct last_snapshot_url" do
-                expect(json_response["last_snapshot_url"]).to eq(camera1.last_snapshot_url)
-            end
-
-            it "returns the correct created_at timestamp" do
-                expect(Time.zone.parse(json_response["created_at"])).to be_within(1.second).of(camera1.created_at)
-            end
-
-            context "within the associated zone data" do
-                it "returns the correct zone id" do
-                    expect(json_response["zone"]["id"]).to eq(zone.id)
-                end
-
-                it "returns the correct zone name" do
-                    expect(json_response["zone"]["name"]).to eq(zone.name)
-                end
             end
         end
 
-        context "with an invalid camera ID" do
-            it "returns a not found http status" do
-                get :show, params: { id: -1 }, format: :json
-                expect(response).to have_http_status(:not_found)
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user) }
+
+            it "can view their own camera" do
+                get :show, params: { id: camera_in_zone.id }, format: :json
+                expect(response).to have_http_status(:ok)
+            end
+
+            it "CANNOT view a camera from another's zone" do
+                get :show, params: { id: camera_in_other_zone.id }, format: :json
+                expect(response).to have_http_status(:forbidden)
             end
         end
     end
 
     describe "POST #create" do
-        before { allow_authentication(admin_user) }
+        let(:valid_params) { { camera: { name: "New Cam", url: "rtsp://valid", zone_id: supervisor_zone.id } } }
 
-        context "with valid parameters" do
-            let(:valid_params) { { camera: { name: "New Cam", url: "rtsp://valid", zone_id: zone.id } } }
+        context "when authenticated as an admin" do
+            before { allow_authentication(admin_user) }
 
-            it "creates a new Camera" do
+            it "can create a camera in any zone" do
+                admin_params = { camera: { name: "Admin Cam", url: "rtsp://admin", zone_id: other_zone.id } }
                 expect {
-                    post :create, params: valid_params, format: :json
+                    post :create, params: admin_params, format: :json
                 }.to change(Camera, :count).by(1)
-            end
-
-            it "returns a created http status" do
-                post :create, params: valid_params, format: :json
                 expect(response).to have_http_status(:created)
-            end
-
-            it "returns a success message" do
-                post :create, params: valid_params, format: :json
-                json_response = JSON.parse(response.body)
-                expect(json_response["message"]).to eq(I18n.t("api.v1.cameras.create.success"))
             end
         end
 
-        context "with invalid parameters" do
-            let(:invalid_params) { { camera: { name: "" } } }
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user) }
 
-            it "does not create a new Camera" do
+            it "can create a camera in their own zone" do
+                expect {
+                    post :create, params: valid_params, format: :json
+                }.to change(Camera, :count).by(1)
+                expect(response).to have_http_status(:created)
+            end
+
+            it "CANNOT create a camera in another's zone" do
+                invalid_params = { camera: { name: "Invalid Cam", url: "rtsp://invalid", zone_id: other_zone.id } }
                 expect {
                     post :create, params: invalid_params, format: :json
                 }.not_to change(Camera, :count)
-            end
-
-            it "returns an unprocessable entity status" do
-                post :create, params: invalid_params, format: :json
-                expect(response).to have_http_status(:unprocessable_entity)
+                expect(response).to have_http_status(:forbidden)
             end
         end
     end
 
     describe "PATCH #update" do
-        before { allow_authentication(admin_user) }
+        let(:new_attributes) { { name: "Updated Name" } }
 
-        context "with valid parameters" do
-            let(:new_attributes) { { name: "Updated Name" } }
-            before { patch :update, params: { id: camera1.id, camera: new_attributes }, format: :json }
+        context "when authenticated as an admin" do
+            before { allow_authentication(admin_user) }
 
-            it "updates the requested camera" do
-                camera1.reload
-                expect(camera1.name).to eq("Updated Name")
-            end
-
-            it "returns an ok http status" do
+            it "can update any camera" do
+                patch :update, params: { id: camera_in_other_zone.id, camera: new_attributes }, format: :json
                 expect(response).to have_http_status(:ok)
-            end
-
-            it "returns a success message" do
-                json_response = JSON.parse(response.body)
-                expect(json_response["message"]).to eq(I18n.t("api.v1.cameras.update.success"))
+                expect(camera_in_other_zone.reload.name).to eq("Updated Name")
             end
         end
 
-        context "with invalid parameters" do
-            it "returns an unprocessable entity status" do
-                patch :update, params: { id: camera1.id, camera: { name: "" } }, format: :json
-                expect(response).to have_http_status(:unprocessable_entity)
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user) }
+
+            it "can update their own camera" do
+                patch :update, params: { id: camera_in_zone.id, camera: new_attributes }, format: :json
+                expect(response).to have_http_status(:ok)
+                expect(camera_in_zone.reload.name).to eq("Updated Name")
+            end
+
+            it "CANNOT update a camera in another's zone" do
+                patch :update, params: { id: camera_in_other_zone.id, camera: new_attributes }, format: :json
+                expect(response).to have_http_status(:forbidden)
+                expect(camera_in_other_zone.reload.name).not_to eq("Updated Name")
             end
         end
     end
 
     describe "DELETE #destroy" do
-        before { allow_authentication(admin_user) }
+        let!(:camera_to_delete) { create(:camera, zone: supervisor_zone) }
 
-        context "when deletion is successful" do
-            let!(:camera_to_delete) { create(:camera, zone: zone) }
+        context "when authenticated as an admin" do
+            before { allow_authentication(admin_user) }
 
             it "destroys the requested camera" do
                 expect {
                     delete :destroy, params: { id: camera_to_delete.id }
                 }.to change(Camera, :count).by(-1)
-            end
-
-            it "returns an ok status with a success message" do
-                delete :destroy, params: { id: camera1.id }
                 expect(response).to have_http_status(:ok)
-                expect(JSON.parse(response.body)["message"]).to eq(I18n.t("api.v1.cameras.destroy.success"))
             end
         end
 
-        context "when destruction fails" do
-            before do
-                allow_any_instance_of(Camera).to receive(:destroy).and_return(false)
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user) }
+
+            it "CANNOT destroy a camera and returns a forbidden status" do
+                delete :destroy, params: { id: camera_to_delete.id }
+                expect(response).to have_http_status(:forbidden)
+                expect(Camera.exists?(camera_to_delete.id)).to be true
             end
-
-            it "returns an unprocessable entity status" do
-                delete :destroy, params: { id: camera1.id }
-                expect(response).to have_http_status(:unprocessable_entity)
-            end
-        end
-    end
-
-    describe "GET #stats" do
-        before do
-            allow_authentication(admin_user)
-            get :stats, format: :json
-        end
-
-        it "returns a successful http status" do
-            expect(response).to have_http_status(:ok)
-        end
-
-        it "returns the total camera count" do
-            expect(JSON.parse(response.body)["total"]).to eq(Camera.count)
         end
     end
 
     describe "POST #capture_and_upload_snapshot" do
-        before { allow_authentication(admin_user) }
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user) }
 
-        context "when snapshot service succeeds" do
-            let(:camera_with_url) { camera1.tap { |c| c.last_snapshot_url = "http://example.com/snap.jpg" } }
+            let(:service_result) { Cameras::SnapshotService::Result.new(success?: true, camera: camera_in_zone, status_code: :ok) }
 
             before do
-                service_result = Cameras::SnapshotService::Result.new(
-                    success?: true, camera: camera_with_url, status_code: :ok
-                )
                 allow_any_instance_of(Cameras::SnapshotService).to receive(:call).and_return(service_result)
-                post :capture_and_upload_snapshot, params: { id: camera1.id }, format: :json
             end
 
-            it "returns a successful http status" do
+            it "can capture a snapshot for their own camera" do
+                post :capture_and_upload_snapshot, params: { id: camera_in_zone.id }, format: :json
                 expect(response).to have_http_status(:ok)
             end
 
-            it "returns a success message and snapshot url" do
-                json_response = JSON.parse(response.body)
-                expect(json_response["message"]).to eq(I18n.t("api.v1.cameras.capture_and_upload_snapshot.success"))
-                expect(json_response["snapshot_url"]).to eq("http://example.com/snap.jpg")
-            end
-        end
-
-        context "when snapshot service fails" do
-            before do
-                error_message = I18n.t("api.v1.cameras.capture_and_upload_snapshot.error")
-                service_result = Cameras::SnapshotService::Result.new(
-                    success?: false, error: "Service failed", status_code: :internal_server_error
-                )
-                allow_any_instance_of(Cameras::SnapshotService).to receive(:call).and_return(service_result)
-                post :capture_and_upload_snapshot, params: { id: camera1.id }, format: :json
-            end
-
-            it "returns an internal server error status" do
-                expect(response).to have_http_status(:internal_server_error)
-            end
-
-            it "returns an error message" do
-                expected_message = I18n.t("api.v1.cameras.capture_and_upload_snapshot.error")
-                expect(JSON.parse(response.body)["error"]).to eq("Service failed")
+            it "CANNOT capture a snapshot for another's camera" do
+                post :capture_and_upload_snapshot, params: { id: camera_in_other_zone.id }, format: :json
+                expect(response).to have_http_status(:forbidden)
             end
         end
     end

--- a/spec/requests/api/v1/sensor_logs_spec.rb
+++ b/spec/requests/api/v1/sensor_logs_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::SensorLogsController, type: :controller do
+    let!(:admin_user) { create(:user, :admin) }
+    let!(:supervisor_user) { create(:user, :supervisor, admin: admin_user) }
+    let!(:supervisor_zone) { create(:zone, user: supervisor_user) }
+    let!(:sensor_in_zone) { create(:sensor, zone: supervisor_zone) }
+    let!(:log_in_zone) { create_list(:sensor_log, 3, sensor: sensor_in_zone) }
+    let!(:other_zone) { create(:zone) }
+    let!(:sensor_in_other_zone) { create(:sensor, zone: other_zone) }
+    let!(:log_in_other_zone) { create(:sensor_log, sensor: sensor_in_other_zone) }
+
+    def allow_authentication(user)
+        allow(controller).to receive(:authenticate_request!).and_return(true)
+        controller.instance_variable_set(:@current_user, user)
+    end
+
+    describe "GET #index" do
+        context "when authenticated as a supervisor" do
+            it "returns only logs from their sensors" do
+                allow_authentication(supervisor_user)
+                get :index, format: :json
+                expect(response).to have_http_status(:ok)
+                json_response = JSON.parse(response.body)
+                expect(json_response["data"].size).to eq(3)
+            end
+        end
+    end
+
+    describe "GET #show" do
+        context "when a supervisor views a log from another's zone" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                get :show, params: { id: log_in_other_zone.id }, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+    end
+
+    describe "DELETE #destroy" do
+        context "when a supervisor tries to delete a log" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                delete :destroy, params: { id: log_in_zone.first.id }, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+
+        context "when an admin fails to delete a log" do
+            it "returns unprocessable entity" do
+                allow_authentication(admin_user)
+                allow_any_instance_of(SensorLog).to receive(:destroy).and_return(false)
+                delete :destroy, params: { id: log_in_zone.first.id }, format: :json
+                expect(response).to have_http_status(:unprocessable_entity)
+            end
+        end
+    end
+
+    describe "GET #stats" do
+        context "when a supervisor tries to get stats" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                get :stats, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+    end
+
+    describe "GET #chart" do
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user) }
+
+            it "is successful with valid params" do
+                get :chart, params: { sensorIds: sensor_in_zone.id.to_s }, format: :json
+                expect(response).to have_http_status(:ok)
+                expect(JSON.parse(response.body)).to have_key(sensor_in_zone.id.to_s)
+            end
+
+            it "returns bad request if sensorIds is missing" do
+                get :chart, format: :json
+                expect(response).to have_http_status(:bad_request)
+            end
+
+            it "ignores invalid time format and returns a successful status with default data" do
+                get :chart, params: { sensorIds: sensor_in_zone.id.to_s, startTime: "invalid-date" }, format: :json
+                expect(response).to have_http_status(:ok)
+                json_response = JSON.parse(response.body)
+                expect(json_response[sensor_in_zone.id.to_s]).not_to be_empty
+            end
+        end
+    end
+end

--- a/spec/requests/api/v1/sensors_spec.rb
+++ b/spec/requests/api/v1/sensors_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::SensorsController, type: :controller do
+    let!(:admin_user) { create(:user, :admin) }
+    let!(:supervisor_user) { create(:user, :supervisor, admin: admin_user) }
+    let!(:other_supervisor) { create(:user, :supervisor, admin: admin_user) }
+    let!(:supervisor_zone) { create(:zone, user: supervisor_user) }
+    let!(:sensor_in_zone) { create(:sensor, zone: supervisor_zone, name: "Supervisor's Sensor") }
+    let!(:other_zone) { create(:zone, user: other_supervisor) }
+    let!(:sensor_in_other_zone) { create(:sensor, zone: other_zone, name: "Other's Sensor") }
+
+    def allow_authentication(user)
+        allow(controller).to receive(:authenticate_request!).and_return(true)
+        controller.instance_variable_set(:@current_user, user)
+    end
+
+    describe "GET #index" do
+        context "when authenticated as a supervisor" do
+            it "returns only their own sensors" do
+                allow_authentication(supervisor_user)
+                get :index, format: :json
+                expect(response).to have_http_status(:ok)
+                json_response = JSON.parse(response.body)
+                expect(json_response["data"].size).to eq(1)
+                expect(json_response["data"][0]["name"]).to eq("Supervisor's Sensor")
+            end
+        end
+    end
+
+    describe "GET #show" do
+        context "when a supervisor views another's sensor" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                get :show, params: { id: sensor_in_other_zone.id }, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+    end
+
+    describe "POST #create" do
+        let(:valid_params) { { sensor: { name: "New Sensor", location: "Warehouse", zone_id: supervisor_zone.id } } }
+
+        context "when a supervisor creates a sensor in another's zone" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                invalid_params = { sensor: { name: "Invalid Sensor", location: "Office", zone_id: other_zone.id } }
+                post :create, params: invalid_params, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+
+        context "with invalid data but valid permissions" do
+            it "returns unprocessable entity" do
+                allow_authentication(supervisor_user)
+                invalid_data_params = { sensor: { name: "", zone_id: supervisor_zone.id } }
+                post :create, params: invalid_data_params, format: :json
+                expect(response).to have_http_status(:unprocessable_entity)
+            end
+        end
+    end
+
+    describe "DELETE #destroy" do
+        let!(:sensor_to_delete) { create(:sensor, zone: supervisor_zone) }
+
+        context "when authenticated as an admin" do
+            it "destroys the sensor" do
+                allow_authentication(admin_user)
+                expect {
+                    delete :destroy, params: { id: sensor_to_delete.id }
+                }.to change(Sensor, :count).by(-1)
+                expect(response).to have_http_status(:ok)
+            end
+        end
+
+        context "when authenticated as a supervisor" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                delete :destroy, params: { id: sensor_to_delete.id }
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+
+        context "when deletion fails" do
+            before do
+                allow_authentication(admin_user)
+                allow_any_instance_of(Sensor).to receive(:destroy).and_return(false)
+            end
+            it "returns unprocessable entity" do
+                delete :destroy, params: { id: sensor_to_delete.id }
+                expect(response).to have_http_status(:unprocessable_entity)
+            end
+        end
+    end
+
+    describe "GET #stats" do
+        context "when authenticated as a supervisor" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                get :stats, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+    end
+
+    describe "POST #bulk" do
+        let(:valid_bulk_params) { { sensors: [{ name: "Bulk 1", location: "A", zone_id: supervisor_zone.id }] } }
+        context "when authenticated as a supervisor" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                post :bulk, params: valid_bulk_params, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+
+        context "when an admin performs a bulk insert with an invalid zone" do
+            before { allow_authentication(admin_user) }
+            let(:invalid_bulk_params) { { sensors: [{ name: "Bulk Invalid", location: "B", zone_id: -99 }] } }
+            it "raises an error and returns unprocessable entity" do
+                post :bulk, params: invalid_bulk_params, format: :json
+                expect(response).to have_http_status(:unprocessable_entity)
+            end
+        end
+    end
+end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::UsersController, type: :controller do
+    let!(:admin_user) { create(:user, :admin) }
+    let!(:supervisor_user_1) { create(:user, :supervisor, admin: admin_user) }
+    let!(:supervisor_user_2) { create(:user, :supervisor, admin: admin_user) }
+
+    def allow_authentication(user)
+        allow(controller).to receive(:authenticate_request!).and_return(true)
+        controller.instance_variable_set(:@current_user, user)
+    end
+
+    describe "GET #index" do
+        context "when authenticated as an admin" do
+            it "returns all users" do
+                allow_authentication(admin_user)
+                get :index, format: :json
+                expect(response).to have_http_status(:ok)
+                expect(JSON.parse(response.body)["data"].size).to eq(3)
+            end
+        end
+
+        context "when authenticated as a supervisor" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user_1)
+                get :index, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+    end
+
+    describe "GET #show" do
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user_1) }
+
+            it "can view their own profile" do
+                get :show, params: { id: supervisor_user_1.id }, format: :json
+                expect(response).to have_http_status(:ok)
+            end
+
+            it "can view their admin's profile" do
+                get :show, params: { id: admin_user.id }, format: :json
+                expect(response).to have_http_status(:ok)
+            end
+
+            it "cannot view another supervisor's profile" do
+                get :show, params: { id: supervisor_user_2.id }, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+    end
+
+    describe "PATCH #update" do
+        let(:update_params) { { user: { name: "Updated Name" } } }
+
+        context "when authenticated as a supervisor" do
+            before { allow_authentication(supervisor_user_1) }
+
+            it "can update their own profile" do
+                patch :update, params: { id: supervisor_user_1.id }.merge(update_params), format: :json
+                expect(response).to have_http_status(:ok)
+                expect(supervisor_user_1.reload.name).to eq("Updated Name")
+            end
+
+            it "cannot update another user's profile" do
+                patch :update, params: { id: supervisor_user_2.id }.merge(update_params), format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+
+        context "when an admin updates a supervisor's profile" do
+            it "is successful" do
+                allow_authentication(admin_user)
+                patch :update, params: { id: supervisor_user_1.id }.merge(update_params), format: :json
+                expect(response).to have_http_status(:ok)
+                expect(supervisor_user_1.reload.name).to eq("Updated Name")
+            end
+        end
+
+        context "with invalid data" do
+            it "returns unprocessable entity" do
+                allow_authentication(supervisor_user_1)
+                patch :update, params: { id: supervisor_user_1.id, user: { name: "" } }, format: :json
+                expect(response).to have_http_status(:unprocessable_entity)
+            end
+        end
+    end
+end

--- a/spec/requests/api/v1/zones_spec.rb
+++ b/spec/requests/api/v1/zones_spec.rb
@@ -1,0 +1,154 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::ZonesController, type: :controller do
+    let!(:admin_user) { create(:user, :admin) }
+    let!(:supervisor_user) { create(:user, :supervisor, admin: admin_user) }
+    let!(:other_supervisor) { create(:user, :supervisor, admin: admin_user) }
+    let!(:supervisor_zone) { create(:zone, user: supervisor_user, name: "Supervisor's Zone") }
+    let!(:other_zone) { create(:zone, user: other_supervisor, name: "Other's Zone") }
+
+    def allow_authentication(user)
+        allow(controller).to receive(:authenticate_request!).and_return(true)
+        controller.instance_variable_set(:@current_user, user)
+    end
+
+    describe "GET #index" do
+        context "when authenticated as an admin" do
+            it "returns all zones" do
+                allow_authentication(admin_user)
+                get :index, format: :json
+                expect(response).to have_http_status(:ok)
+                expect(JSON.parse(response.body)["data"].size).to eq(2)
+            end
+        end
+
+        context "when authenticated as a supervisor" do
+            it "returns only their own zones" do
+                allow_authentication(supervisor_user)
+                get :index, format: :json
+                expect(response).to have_http_status(:ok)
+                json_response = JSON.parse(response.body)
+                expect(json_response["data"].size).to eq(1)
+                expect(json_response["data"][0]["name"]).to eq("Supervisor's Zone")
+            end
+        end
+    end
+
+    describe "GET #show" do
+        context "when a supervisor views their own zone" do
+            it "is successful" do
+                allow_authentication(supervisor_user)
+                get :show, params: { id: supervisor_zone.id }, format: :json
+                expect(response).to have_http_status(:ok)
+            end
+        end
+
+        context "when a supervisor views another's zone" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                get :show, params: { id: other_zone.id }, format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+    end
+
+    describe "POST #create" do
+        let(:valid_params) { { zone: { name: "New Zone", city: "HCMC" } } }
+
+        context "when a supervisor creates a zone" do
+            before { allow_authentication(supervisor_user) }
+
+            it "creates a zone and assigns it to themself" do
+                expect {
+                    post :create, params: valid_params, format: :json
+                }.to change(supervisor_user.zones, :count).by(1)
+                expect(response).to have_http_status(:created)
+            end
+        end
+
+        context "when an admin creates a zone for a supervisor" do
+            before { allow_authentication(admin_user) }
+            let(:admin_params) { { zone: { name: "Admin Assigned Zone", user_id: other_supervisor.id } } }
+
+            it "creates a zone for the specified supervisor" do
+                expect {
+                    post :create, params: admin_params, format: :json
+                }.to change(other_supervisor.zones, :count).by(1)
+                expect(response).to have_http_status(:created)
+            end
+        end
+
+        context "with invalid data" do
+            before { allow_authentication(admin_user) }
+            it "returns unprocessable entity" do
+                post :create, params: { zone: { name: "" } }, format: :json
+                expect(response).to have_http_status(:unprocessable_entity)
+            end
+        end
+    end
+
+    describe "PATCH #update" do
+        let(:update_params) { { zone: { name: "Updated Zone Name" } } }
+
+        context "when a supervisor updates their own zone" do
+            it "is successful" do
+                allow_authentication(supervisor_user)
+                patch :update, params: { id: supervisor_zone.id }.merge(update_params), format: :json
+                expect(response).to have_http_status(:ok)
+                expect(supervisor_zone.reload.name).to eq("Updated Zone Name")
+            end
+        end
+
+        context "when a supervisor updates another's zone" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                patch :update, params: { id: other_zone.id }.merge(update_params), format: :json
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+
+        context "with invalid data" do
+            before { allow_authentication(supervisor_user) }
+            it "returns unprocessable entity" do
+                patch :update, params: { id: supervisor_zone.id, zone: { name: "" } }, format: :json
+                expect(response).to have_http_status(:unprocessable_entity)
+            end
+        end
+    end
+
+    describe "DELETE #destroy" do
+        let!(:zone_to_delete) { create(:zone, user: supervisor_user) }
+
+        context "when a supervisor deletes their own zone" do
+            it "is successful" do
+                allow_authentication(supervisor_user)
+                expect {
+                    delete :destroy, params: { id: zone_to_delete.id }, format: :json
+                }.to change(Zone, :count).by(-1)
+                expect(response).to have_http_status(:ok)
+            end
+        end
+
+        context "when a supervisor deletes another's zone" do
+            it "is forbidden" do
+                allow_authentication(supervisor_user)
+                expect {
+                    delete :destroy, params: { id: other_zone.id }, format: :json
+                }.not_to change(Zone, :count)
+                expect(response).to have_http_status(:forbidden)
+            end
+        end
+
+        context "when deletion fails" do
+            before do
+                allow_authentication(supervisor_user)
+                allow_any_instance_of(Zone).to receive(:destroy).and_return(false)
+            end
+
+            it "returns unprocessable entity" do
+                delete :destroy, params: { id: supervisor_zone.id }, format: :json
+                expect(response).to have_http_status(:unprocessable_entity)
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Checklist tự review pull trước khi ready nhờ trainer review
- [x] Kiểm tra mỗi pull request 1 commit, nếu nhiều commit thì hãy gộp commit thành 1 rồi đẩy lại lên git
- [x] Trong các file của rails (đuôi .erb, .rb, .yml): sử dụng nháy " thay vì nháy '
- [x] Trong file javascript: sử dụng nháy ' thay vì "
- [x] Sử dụng thụt lề 2 space (setting lại vscode /sublime text nếu chưa cài đặt)
- [x] Cuối mỗi file kiểm tra có end line (khi đẩy lên git xem file change k bị lỗi tròn đỏ ở cuối file)
- [x] Mỗi dòng nếu quá dài, cần xuống dòng (maximum: 80 kí tự mỗi dòng)
- [x] Xóa các file được tự động sinh ra khi dùng các câu lệnh rails generate ... tạo ra nhưng k dùng đến, không có dòng code nào được viết trong đó (hay gặp nhất là các file helper)
- [x] Khi tạo mảng, nên tích cực sử dụng %w( ), %i() . Thay vì STATES = ['draft', 'open', 'closed'] có thể dùng STATES = %w(draft open closed)
- [x] Xem các lỗi hay gặp khi triển khai Rails tutorial tại https://docs.google.com/document/d/104Csp4-vamVos5DEbi372nLBEfmqhj7h1ENYO8ebjCo/edit
- [x] Tham khảo coding convention https://github.com/framgia/coding-standards/blob/master/vn/README.md

## Related Tickets
## WHAT (optional)
- refactor rspec module camera (after update gem cancancan)
- set up rspec all module include 
  + alert , cameras, sensor, sensor_log , user , zone 
 - fix issue telegram conflict gem (l18n) replace by call directly message body
## Evidence (Screenshot or Video)
<img width="2160" height="1350" alt="image" src="https://github.com/user-attachments/assets/4293c9ea-e905-4425-a68d-0c4654bd5273" />
<img width="2160" height="1350" alt="image" src="https://github.com/user-attachments/assets/5419a0da-7bc1-4266-89ef-3ecad56ef7b5" />
<img width="2160" height="1350" alt="image" src="https://github.com/user-attachments/assets/555eba2e-ca6b-4146-a0f8-463f510882d2" />
## test image

## cameras

<img width="773" height="154" alt="image" src="https://github.com/user-attachments/assets/e854e1d3-6987-41b0-b4b6-764d45ac9ba1" />

<img width="818" height="158" alt="image" src="https://github.com/user-attachments/assets/cb5dc8bd-0529-4e8e-b4b2-35b823e1465f" />

## zones
<img width="760" height="158" alt="image" src="https://github.com/user-attachments/assets/df4cf9a0-5b44-4aed-947f-f28361f7600f" />
<img width="805" height="161" alt="image" src="https://github.com/user-attachments/assets/529e63da-e296-4430-bf21-75548b0929ac" />

## users
<img width="730" height="157" alt="image" src="https://github.com/user-attachments/assets/3fd08e25-d34d-4e3a-8caa-8e8c2cea24cf" />

<img width="804" height="153" alt="image" src="https://github.com/user-attachments/assets/edaed5f2-3c73-48f4-a2d2-07cdba05e0fe" />

## alert

<img width="767" height="151" alt="image" src="https://github.com/user-attachments/assets/762e62ad-6ebf-461b-bc8c-fc758e75794b" />

<img width="815" height="146" alt="image" src="https://github.com/user-attachments/assets/e35c2069-9d33-4cd7-9b0b-748d14802be9" />

## sensor 
<img width="773" height="163" alt="image" src="https://github.com/user-attachments/assets/3d4d4cb4-8256-452b-827c-bfcff45c9066" />
<img width="818" height="152" alt="image" src="https://github.com/user-attachments/assets/2a7f3fef-37c9-42c9-bfa6-6f9bc18c07a3" />

## sensor log
<img width="791" height="143" alt="image" src="https://github.com/user-attachments/assets/70a16b0f-94a6-4c2e-a059-b03ecbe22f73" />

<img width="930" height="154" alt="image" src="https://github.com/user-attachments/assets/ee925932-b2c2-4691-8668-06ca30e1af90" />



